### PR TITLE
[JS FK] Add missing item type icons and support for Legendary items

### DIFF
--- a/src/components/table/cells.tsx
+++ b/src/components/table/cells.tsx
@@ -97,7 +97,7 @@ export function PlayerItem(props: { player: Player }): JSX.Element {
         Cape: "👗",
         Field: "🔵",
         Glove: "🧤",
-        Helmet: "🪖",
+        Helmet: "⛑",
         Jersey: "👕",
         Necklace: "📿",
         Phone: "☎️",

--- a/src/components/table/cells.tsx
+++ b/src/components/table/cells.tsx
@@ -88,15 +88,25 @@ export function PlayerItem(props: { player: Player }): JSX.Element {
         [key: string]: string;
     };
     const rootNameMap: itemMap = {
+        Base: "⬜",
         Bat: "🏏",
         Board: "🛹",
+        Broom: "🧹",
+        Cannon: "🔫",
         Cap: "🧢",
+        Cape: "👗",
         Field: "🔵",
         Glove: "🧤",
+        Helmet: "🪖",
         Jersey: "👕",
         Necklace: "📿",
+        Phone: "☎️",
+        Pillow: "🛏️",
+        Potion: "🧪",
+        Quill: "🪶",
         Ring: "💍",
         Shoes: "👟",
+        Socks: "🧦",
         Sunglasses: "🕶️",
     };
 
@@ -119,7 +129,7 @@ export function PlayerItem(props: { player: Player }): JSX.Element {
                         }
                     >
                         <div className="item-icon">
-                            {rootNameMap[item.root.name]}
+                            {rootNameMap[item.root.name] ?? "❔"}
                             {item.health === 0 ? (
                                 <span className="broken-item">❌</span>
                             ) : (

--- a/src/components/table/cells.tsx
+++ b/src/components/table/cells.tsx
@@ -118,17 +118,19 @@ export function PlayerItem(props: { player: Player }): JSX.Element {
                     <Tooltip
                         placement="top"
                         overlay={
-                            <span>
+                            <span className={item.durability === -1 ? 'legendary-item-name' : ''}>
                                 {item.name}{" "}
                                 <i>
-                                    {item.health === 0
-                                        ? " (broken)"
-                                        : `(${item.health}/${item.durability})`}
+                                    {item.durability === -1
+                                        ? "(∞)"
+                                        : (item.health === 0
+                                            ? "(broken)"
+                                            : `(${item.health}/${item.durability})`)}
                                 </i>
                             </span>
                         }
                     >
-                        <div className="item-icon">
+                        <div className={`item-icon ${item.durability === -1 ? 'legendary-item' : ''}`}>
                             {rootNameMap[item.root.name] ?? "❔"}
                             {item.health === 0 ? (
                                 <span className="broken-item">❌</span>

--- a/src/components/table/stats.tsx
+++ b/src/components/table/stats.tsx
@@ -54,10 +54,10 @@ function NumericStat(props: {
                         {itemValues.map((i) => {
                             const sign = i.value > 0 ? "+" : "";
                             return (
-                                <span key={i.item.data.id}>
-                                    {i.item.data.name}: {sign}
+                                <div key={i.item.data.id}>
+                                    <span className={i.item.data.durability === -1 ? 'legendary-item-name' : ''}>{i.item.data.name}</span>: {sign}
                                     {i.value.toFixed(3)}
-                                </span>
+                                </div>
                             );
                         })}
                     </div>

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -126,12 +126,24 @@ html, body, .app {
 .item-icon {
     position: relative;
     display: inline-block;
+    width: 1.5em;
 }
 
 .broken-item {
     position: absolute;
     top: 0;
     left: 0;
+}
+
+.legendary-item {
+    border-radius: 50%;
+    box-shadow: inset 0 0 5px 1px #ffc81e;
+    margin: 0 0.05em 0 0.05em;
+}
+
+.legendary-item-name {
+    color: #ffc81e;
+    text-shadow: 0 0 0.7em #ffc81e;
 }
 
 .rc-tooltip {

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -151,5 +151,6 @@ html, body, .app {
 
     .rc-tooltip-inner {
         background-color: #444;
+        text-align: center;
     }
 }


### PR DESCRIPTION
This PR adds emojis for the 10 missing item types (**including currently-FK ones**), adds a fallback emoji (❔), and adds support for Legendary items (showing the infinity symbol for durability and stylising the name and icon). Not all of the item types had one-to-one corresponding emojis – I used 👗 for Cape, 🔫 for Cannon, and 🛏 for Pillow. It's also worth mentioning that the 🪶 (feather - Quill) emoji is not currently supported by Windows, nor will it be added until around October. Similarly, I think 🪖 (military helmet) fits better than ⛑ (rescue worker's helmet) for Helmet, but I went with the latter since the former is not yet supported in Windows.