### PR TITLE
Implement Chronicler pagination

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -4,6 +4,7 @@ import {
     BlaseballPlayer,
     BlaseballTeam,
     ChroniclerEntities,
+    ChroniclerEntity,
     PlayerMod,
 } from "./types";
 import queryString from "query-string";
@@ -22,12 +23,12 @@ export async function fetchLeagueData(at: string | null): Promise<LeagueData> {
     ]);
 
     const teamMap = Object.fromEntries(
-        teams.items.map((t) => [t.entityId, t.data])
+        teams.map((t) => [t.entityId, t.data])
     );
-    const rosterMap = generatePlayerTeamMap(teams.items);
+    const rosterMap = generatePlayerTeamMap(teams);
     const modMap = Object.fromEntries(mods.map((m) => [m.id, m]));
     const playerObjects = Object.fromEntries(
-        players.items.map((p) => [
+        players.map((p) => [
             p.entityId,
             new Player(p, teamMap, rosterMap),
         ])
@@ -43,14 +44,9 @@ export async function fetchLeagueData(at: string | null): Promise<LeagueData> {
 
 async function fetchPlayersAndMods(
     at: string | null
-): Promise<[ChroniclerEntities<BlaseballPlayer>, PlayerMod[]]> {
-    const players = await fetchJson<ChroniclerEntities<BlaseballPlayer>>(
-        queryString.stringifyUrl({
-            url: "https://api.sibr.dev/chronicler/v2/entities",
-            query: { type: "player", at: at ?? undefined },
-        })
-    );
-    const modIds = getAllModIds(players.items);
+): Promise<[ChroniclerEntity<BlaseballPlayer>[], PlayerMod[]]> {
+    const players = await fetchEntities<BlaseballPlayer>("player", at);
+    const modIds = getAllModIds(players);
     const mods = await fetchJson<PlayerMod[]>(
         "https://api.sibr.dev/proxy/database/mods?ids=" + modIds.join(",")
     );
@@ -59,13 +55,27 @@ async function fetchPlayersAndMods(
 
 async function fetchTeams(
     at: string | null
-): Promise<ChroniclerEntities<BlaseballTeam>> {
-    return await fetchJson<ChroniclerEntities<BlaseballTeam>>(
-        queryString.stringifyUrl({
-            url: "https://api.sibr.dev/chronicler/v2/entities",
-            query: { type: "team", at: at ?? undefined },
-        })
-    );
+): Promise<ChroniclerEntity<BlaseballTeam>[]> {
+    return await fetchEntities<BlaseballTeam>("team", at);
+}
+
+async function fetchEntities<T>(
+    type: string, at: string | null
+) : Promise<ChroniclerEntity<T>[]> {
+    const pages: ChroniclerEntities<T>[] = [];
+    do {
+        pages.push(await fetchJson<ChroniclerEntities<T>>(
+            queryString.stringifyUrl({
+                url: "https://api.sibr.dev/chronicler/v2/entities",
+                query: {
+                    type: type,
+                    at: at ?? undefined,
+                    page: pages[pages.length - 1]?.nextPage ?? undefined
+                },
+            })
+        ));
+    } while (pages[pages.length - 1]?.nextPage);
+    return pages.flatMap((page) => page.items);
 }
 
 async function fetchJson<T>(url: string): Promise<T> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -84,6 +84,7 @@ export interface ChroniclerResponseV1<T> {
 }
 
 export interface ChroniclerEntities<T> {
+    nextPage: string | null;
     items: ChroniclerEntity<T>[];
 }
 


### PR DESCRIPTION
Chronicler's `/v2/entities?type=player` endpoint recently crossed the pagination threshold of 1000 players, but the player viewer currently only fetches the first page. This PR implements Chron's pagination, dynamically fetching all available pages.